### PR TITLE
escaping parenthesi for egrep (didn't work as is)

### DIFF
--- a/cleanup-pnp4nagios.sh
+++ b/cleanup-pnp4nagios.sh
@@ -2,7 +2,7 @@
 
 folder="${1:-/var/pnp4nagios/perfdata}"
 
-files=$(egrep -l "(expected [0-9]* data source readings (got [0-9]*) from|found extra data on update argument)" $(find ${folder} -name '*.xml'))
+files=$(egrep -l "(expected [0-9]* data source readings \(got [0-9]*\) from|found extra data on update argument)" $(find ${folder} -name '*.xml'))
 
 for found in $(echo $files); do
   filename=${found%.*} 


### PR DESCRIPTION
Sorry, missed that the first time around.

If this is working for you as is, then I need to revisit this - perhaps it depends on egrep version.   I can also change ( to . 
